### PR TITLE
adjust singleton signature to match later civi versions

### DIFF
--- a/CRM/Core/Payment/AuthNetEcheck.php
+++ b/CRM/Core/Payment/AuthNetEcheck.php
@@ -29,11 +29,14 @@ class CRM_Core_Payment_AuthNetEcheck extends CRM_Core_Payment_AuthorizeNet {
    *
    * @param string $mode the mode of operation: live or test
    *
+   * @param object $paymentProcessor
+   * @param CRM_Core_Form $paymentForm
+   * @param bool $force
+   *
    * @return object
    * @static
-   *
    */
-  static function &singleton($mode, &$paymentProcessor) {
+  static function &singleton($mode, &$paymentProcessor, &$paymentForm = NULL, $force = FALSE) {
       $processorName = $paymentProcessor['name'];
       if (!isset(self::$_singleton[$processorName]) || self::$_singleton[$processorName] === NULL) {
         self::$_singleton[$processorName] = new CRM_Core_Payment_AuthNetEcheck($mode, $paymentProcessor);


### PR DESCRIPTION
The signature changed in ?4.3?, certainly 4.4 & 4.5 use this signature. Unfortunately there is no way to
be correct for all versions so being correct for the later versions makes sense (esp since they are more e-notice compliant in general
